### PR TITLE
Update Newtonsoft.Json from 5.0.4 to 6.0.4

### DIFF
--- a/source/SlimRest/Client/RestWebClient.cs
+++ b/source/SlimRest/Client/RestWebClient.cs
@@ -87,7 +87,7 @@ namespace SlimRest.Client
             var webRequest = BuildRequest(request, method);
             using (var requestStream = new StreamWriter(webRequest.GetRequestStream()))
             {
-                var json = await JsonConvert.SerializeObjectAsync(request.Data);
+                var json = await Task.Factory.StartNew(() => JsonConvert.SerializeObject(request.Data));
                 await requestStream.WriteAsync(json);
             }
 
@@ -252,7 +252,7 @@ namespace SlimRest.Client
             {
                 await jsonStream.CopyToAsync(contentStream);
                 var content = Encoding.UTF8.GetString(contentStream.ToArray());
-                return await JsonConvert.DeserializeObjectAsync<T>(content);
+                return await Task.Factory.StartNew(() => JsonConvert.DeserializeObject<T>(content));
             }
         }
 

--- a/source/SlimRest/SlimRest.csproj
+++ b/source/SlimRest/SlimRest.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -14,6 +14,7 @@
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
     <BuildPackage>true</BuildPackage>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -24,6 +25,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -33,6 +35,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup>
     <StartupObject />
@@ -45,7 +48,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Newtonsoft.Json">
-      <HintPath>..\..\packages\Newtonsoft.Json.5.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\..\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -82,6 +85,5 @@
   <Target Name="BeforeBuild">
   </Target>
   -->
-
   <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
 </Project>

--- a/source/SlimRest/SlimRest.nuspec
+++ b/source/SlimRest/SlimRest.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>SlimRest</id>
-    <version>1.1.0.1</version>
+    <version>1.2.0.0</version>
     <title>SlimRest</title>
     <authors>Scott Meyer</authors>
     <owners>Scott Meyer</owners>
@@ -10,11 +10,11 @@
     <projectUrl>https://github.com/scottmeyer/SlimRest</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>A simple synchronous/asynchronous REST client for .Net</description>
-    <releaseNotes>The assembly is now signed.</releaseNotes>
+    <releaseNotes>Updates to Newtonsoft.Json 6.0.4</releaseNotes>
     <copyright>Copyright 2013</copyright>
     <tags>REST api client</tags>
     <dependencies>
-      <dependency id="Newtonsoft.Json" version="5.0.4" />
+      <dependency id="Newtonsoft.Json" version="6.0.4" />
     </dependencies>
   </metadata>
   <files>

--- a/source/SlimRest/packages.config
+++ b/source/SlimRest/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="5.0.4" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
- Updates to `6.0.4`
- Updates `Async` methods to no longer use obsoleted methods from `Newtonsoft.Json` library.
